### PR TITLE
Adjust event description to event code converter

### DIFF
--- a/messageparser.go
+++ b/messageparser.go
@@ -38,8 +38,10 @@ var eventTypeMap = map[string]IseLogEvent{
 
 // StrToIseLogEvent converts the text label of an ISE log's CVS message to an enum.
 func StrToIseLogEvent(event string) IseLogEvent {
-	if eventCode, ok := eventTypeMap[event]; ok {
-		return eventCode
+	for description, code := range eventTypeMap {
+		if strings.Contains(event, description) {
+			return code
+		}
 	}
 	return 0
 }


### PR DESCRIPTION
Since some ISE logs have a timestamp prepended to the event description, this PR changes the description-to-event code map function to now use a Contains check, instead of just checking if the description matches an existing key-value in the description-event map.